### PR TITLE
allowing client bookmarks to be written

### DIFF
--- a/tap_mambu/tap_generators/clients_generator.py
+++ b/tap_mambu/tap_generators/clients_generator.py
@@ -19,6 +19,3 @@ class ClientsGenerator(MultithreadedBookmarkGenerator):
     def prepare_batch_params(self):
         super(ClientsGenerator, self).prepare_batch_params()
         self.endpoint_filter_criteria[0]["value"] = datetime_to_local_str(self.endpoint_intermediary_bookmark_value)
-
-    def write_sub_stream_bookmark(self, start):
-        pass


### PR DESCRIPTION
# Description of change
In the state record in the output of the tap-mambu doesn't contain a bookmark for clients. Modifying the code for it's inclusion.

# Risks
 - 
 
# Rollback steps
 - revert this branch
